### PR TITLE
chassis: Add library function to validate fabric is up

### DIFF
--- a/library/check_fabric.py
+++ b/library/check_fabric.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python2.7
+
+import subprocess
+import cumulus.chassis
+from ansible.module_utils.basic import *
+
+def main():
+    module = AnsibleModule(argument_spec=dict())
+
+    # Get BGP neighbor information
+    output = subprocess.check_output(["/usr/bin/net", "show", "bgp", "neighbor", "json"])
+    neighInfo = json.loads(output)
+
+    # Make sure we are running on a chassis
+    try:
+        chassis = cumulus.chassis.probe()
+    except (ImportError, RuntimeError, AssertionError) as e:
+        module.fail_json(changed=False, msg="Unable to determine chassis type: %s" % (e,))
+
+    # Does each fabric port have an established BGP session?
+    failIntfs = []
+    for fabNum in xrange(chassis.GetNumFabIntfs()):
+        fabIntf = "fp%d" % fabNum
+        if neighInfo.get(fabIntf, {}).get("bgpState") != "Established":
+            failIntfs.append(fabIntf)
+
+    if failIntfs:
+        module.fail_json(changed=False, msg="Fabric interfaces have not established BGP: " + " ".join(failIntfs))
+
+    module.exit_json(changed=False, msg="BGP is established on all fabric interfaces")
+
+if __name__ == '__main__':
+    main()

--- a/roles/fabriccard_common/tasks/upgrade.yml
+++ b/roles/fabriccard_common/tasks/upgrade.yml
@@ -66,3 +66,7 @@
 
 - name: Commit the change
   command: net commit
+
+- name: Check that fabric BGP is established
+  any_errors_fatal: true
+  check_fabric:

--- a/roles/linecard_common/tasks/upgrade.yml
+++ b/roles/linecard_common/tasks/upgrade.yml
@@ -65,3 +65,7 @@
 
 - name: Commit the change
   command: net commit
+
+- name: Check that fabric BGP is established
+  any_errors_fatal: true
+  check_fabric:


### PR DESCRIPTION
After upgrading the software on a portion of the chassis it is a good idea to
check if the upgrade succeeded before proceeding to upgrade other portions of
the chassis. This commit adds a check_fabric library function which looks to
see if BGP sessions are established on all of the fabric interfaces of the
line card or fabric card that was upgraded. This provides a minimal level of
comfort that the upgrade succeeded.